### PR TITLE
:hammer: making sure that only img > src is prepend

### DIFF
--- a/blog/post.php
+++ b/blog/post.php
@@ -77,7 +77,7 @@ else if((substr($selectedPost->file, strlen($selectedPost->file) - 2) === 'md'))
     // replace references to local markdown directory with full path from website root
     $pattern = array();
     $replacement = array();
-    $pattern[0] = '/src="((.)+)" /';
+    $pattern[0] = '/<img src="((.)+)"/';
     $pattern[1] = '/a href="files\/((.)+)">/';
     $pattern[2] = '/<code class="/';
     $pattern[3] = '/<code>/';


### PR DESCRIPTION
When using `<iframe src="">` within the markdown it get prepended by the current article folder. Furthermore, the space at the end of the regex force the `<img>` to have one more attribute after the `src=` one, which doesn't works in a lot of situation.